### PR TITLE
Add missing #include for <algorithm>

### DIFF
--- a/src/osgbCollision/CollisionShapes.cpp
+++ b/src/osgbCollision/CollisionShapes.cpp
@@ -38,7 +38,7 @@
 #include <osg/Timer>
 #include <osg/io_utils>
 #include <iostream>
-
+#include <algorithm>
 
 namespace osgbCollision
 {


### PR DESCRIPTION
`std::max` is defined in `<algorithm>`. Fixes build failure with Visual
Studio 2013 on Windows 10.

http://www.cplusplus.com/reference/algorithm/